### PR TITLE
feat: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugRepport.yaml
+++ b/.github/ISSUE_TEMPLATE/bugRepport.yaml
@@ -1,0 +1,63 @@
+name: Bug repport
+description: Create a bug report to help me improve
+title: "<title>"
+labels: ["bug"]
+
+body:
+    - type: textarea
+      id: summary
+      attributes:
+          label: Summary
+          description: One sentence description of what the bug is
+          render: markdown
+      validations:
+          required: true
+
+    - type: textarea
+      id: step-to-reproduced
+      attributes:
+          label: How to reproduced
+          description: The steps to recreate this bug
+          value: |
+              1. Go to '...'
+              2. Click on '....'
+              3. Scroll down to '....'
+              4. **See error**
+          render: markdown
+      validations:
+          required: true
+
+    - type: textarea
+      id: exepted-behavior
+      attributes:
+          label: Expected behavior
+          description: A clear and concise description of what you expected to happen
+          render: markdown
+      validations:
+          required: true
+
+    - type: textarea
+      id: screenshot
+      attributes:
+          label: Screenshot
+          description: If needed paste here some screenshot of the bug
+      validations:
+          required: false
+
+    - type: textarea
+      id: stacktrace
+      attributes:
+          label: Stacktrace
+          description: If you have a stacktrace or log, paste it between the quoted lines below
+          render: shell
+      validations:
+          required: false
+
+    - type: textarea
+      id: other-detail
+      attributes:
+          label: Other detail
+          description: Add any other context about the problem here. If not, leave blank
+          render: markdown
+      validations:
+          required: false

--- a/.github/ISSUE_TEMPLATE/improvement.yaml
+++ b/.github/ISSUE_TEMPLATE/improvement.yaml
@@ -1,0 +1,47 @@
+name: Improvement to existing functionality
+description: Suggest an improvement to something that already exists
+labels: ["improvement", "needs triage"]
+assignees: []
+
+body:
+    - type: textarea
+      id: summary
+      attributes:
+          label: Summary
+          value: One sentence summary of how something can be better.
+          render: markdown
+      validations:
+          required: true
+
+    - type: textarea
+      id: background
+      attributes:
+          label: Background
+          description: |
+              Is your improvement related to a problem? Please describe
+
+              A clear and concise description of what the problem is. Ex. I'm frustrated when [...]
+
+    - type: textarea
+      id: solution
+      attributes:
+          label: Describe the solution you'd like
+          description: A clear and concise description of what you want to happen.
+
+    - type: textarea
+      id: alternatives
+      attributes:
+          label: Describe alternatives you've considered
+          description: A clear and concise description of any alternative solutions or features you've considered.
+
+    - type: textarea
+      id: details
+      attributes:
+          label: Details
+          description: Details to understand how this task should be completed or carried out. What are the next steps? Add any other context or screenshots about the feature request here.
+
+    - type: textarea
+      id: outcome
+      attributes:
+          label: Outcome
+          description: One sentence to describe what the end result will be once this ticket is complete.

--- a/.github/ISSUE_TEMPLATE/newFeature.yaml
+++ b/.github/ISSUE_TEMPLATE/newFeature.yaml
@@ -1,0 +1,43 @@
+name: New feature request
+description: Suggest a new idea for this project
+labels: ["needs triage", "new change"]
+assignees: []
+
+body:
+    - type: textarea
+      attributes:
+          label: Summary
+          description: One sentence summary of how something can be better.
+
+    - type: textarea
+      id: background
+      attributes:
+          label: Background
+          description: |
+              Is your feature request related to a problem? Please describe
+
+              A clear and concise description of what the problem is. Ex. I'm frustrated when [...]
+
+    - type: textarea
+      id: solution
+      attributes:
+          label: Describe the solution you'd like
+          description: A clear and concise description of what you want to happen.
+
+    - type: textarea
+      id: alternatives
+      attributes:
+          label: Describe alternatives you've considered
+          description: A clear and concise description of any alternative solutions or features you've considered.
+
+    - type: textarea
+      id: details
+      attributes:
+          label: Details
+          description: Details to understand how this task should be completed or carried out. What are the next steps? Add any other context or screenshots about the feature request here.
+
+    - type: textarea
+      id: outcome
+      attributes:
+          label: Outcome
+          description: One sentence to describe what the end result will be once this ticket is complete.


### PR DESCRIPTION
This pull request introduces three new issue templates to streamline the process of reporting bugs, suggesting improvements, and requesting new features. These templates aim to provide clear structures for contributors to share relevant details, improving issue tracking and triage.

### New issue templates:

* **Bug Report Template**: Added a structured template for reporting bugs, including fields for summary, reproduction steps, expected behavior, screenshots, stack traces, and additional details. (`.github/ISSUE_TEMPLATE/bugRepport.yaml`)

* **Improvement Suggestion Template**: Added a template for suggesting improvements to existing functionality, with fields for summary, background, proposed solution, alternatives, details, and outcome. (`.github/ISSUE_TEMPLATE/improvement.yaml`)

* **New Feature Request Template**: Added a template for proposing new features, including fields for summary, background, proposed solution, alternatives, details, and outcome. (`.github/ISSUE_TEMPLATE/newFeature.yaml`)