### PR TITLE
Feat/manual transitions

### DIFF
--- a/.auto-changelog
+++ b/.auto-changelog
@@ -5,7 +5,7 @@
   "commitLimit": false,
   "breakingPattern": "BREAKING CHANGE:",
   "issuePattern": "#(\\d+)",
-  "issueUrl": "https://github.com/VOTRE_UTILISATEUR/pomodoro-timer/issues/{id}",
+  "issueUrl": "https://github.com/quentinformatique/pomodoro-timer/issues/{id}",
   "replaceText": {
     "feat:": "Features",
     "fix:": "Bug Fixes",

--- a/src/Views/Components/Settings/Sections/TimerSettings.tsx
+++ b/src/Views/Components/Settings/Sections/TimerSettings.tsx
@@ -1,12 +1,14 @@
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SettingsInput } from '../SettingsInput';
+import { Icon } from '../../Utilities/Icon';
 
 interface PomodoroSettings {
     workDuration: number;
     shortBreakDuration: number;
     longBreakDuration: number;
     cyclesBeforeLongBreak: number;
+    manualMode: boolean;
 }
 
 interface TimerSettingsProps {
@@ -14,7 +16,8 @@ interface TimerSettingsProps {
     shortBreakDuration: number;
     longBreakDuration: number;
     cyclesBeforeLongBreak: number;
-    onSettingChange: (key: keyof PomodoroSettings, value: number) => void;
+    manualMode: boolean;
+    onSettingChange: (key: keyof PomodoroSettings, value: number | boolean) => void;
 }
 
 export const TimerSettings: FC<TimerSettingsProps> = ({
@@ -22,12 +25,13 @@ export const TimerSettings: FC<TimerSettingsProps> = ({
     shortBreakDuration,
     longBreakDuration,
     cyclesBeforeLongBreak,
+    manualMode,
     onSettingChange
 }) => {
     const { t } = useTranslation();
 
     return (
-        <div className="space-y-4 min-h-[16rem]">
+        <div className="space-y-0 sm:space-y-4 min-h-[16rem]">
             <SettingsInput
                 label={t('settings.durations.workDuration')}
                 value={workDuration}
@@ -60,6 +64,41 @@ export const TimerSettings: FC<TimerSettingsProps> = ({
                 max={10}
                 unit={t('settings.units.cycles')}
             />
+            <div className="flex items-center justify-between py-3">
+                <div className="flex-1 md:mr-16 lg:mr-24">
+                    <div className="flex items-center gap-2">
+                        <Icon 
+                            code={manualMode ? "touch_app" : "autorenew"} 
+                            fill={manualMode}
+                            className="text-xl text-green-light"
+                        />
+                        <span className="text-green-light block">
+                            {manualMode 
+                                ? t('settings.mode.manualMode')
+                                : t('settings.mode.autoMode')}
+                        </span>
+                    </div>
+                    <span className="text-green-light/70 text-sm block mt-1 ml-7">
+                        {manualMode 
+                            ? t('settings.mode.manualModeDescription')
+                            : t('settings.mode.autoModeDescription')}
+                    </span>
+                </div>
+                <button
+                    onClick={() => onSettingChange("manualMode", !manualMode)}
+                    className={`p-2 rounded-lg transition-colors ${
+                        manualMode 
+                            ? 'text-green-light bg-green-light/10' 
+                            : 'text-green-light/50 hover:text-green-light hover:bg-green-light/10'
+                    }`}
+                >
+                    <Icon 
+                        code={manualMode ? "touch_app" : "autorenew"} 
+                        fill={manualMode}
+                        className="text-2xl"
+                    />
+                </button>
+            </div>
         </div>
     );
 }; 

--- a/src/Views/Components/Settings/Settings.tsx
+++ b/src/Views/Components/Settings/Settings.tsx
@@ -14,6 +14,7 @@ interface PomodoroSettings {
     shortBreakDuration: number;
     longBreakDuration: number;
     cyclesBeforeLongBreak: number;
+    manualMode: boolean;
 }
 
 const defaultSettings: PomodoroSettings = {
@@ -21,6 +22,7 @@ const defaultSettings: PomodoroSettings = {
     shortBreakDuration: 5,
     longBreakDuration: 15,
     cyclesBeforeLongBreak: 4,
+    manualMode: false,
 };
 
 type SettingsPage = 'timer' | 'appearance' | 'notifications';
@@ -44,7 +46,7 @@ export const Settings: FC = () => {
         notifications: { icon: 'notifications', title: t('settings.notifications.title') }
     };
 
-    const handleSettingChange = (key: keyof PomodoroSettings, value: number) => {
+    const handleSettingChange = (key: keyof PomodoroSettings, value: number | boolean) => {
         setSettings(prev => {
             const newSettings = { ...prev, [key]: value };
             // Sauvegarder immédiatement les changements

--- a/src/Views/Components/Settings/Settings.tsx
+++ b/src/Views/Components/Settings/Settings.tsx
@@ -34,7 +34,7 @@ export const Settings: FC = () => {
     const [hasChanges, setHasChanges] = useState(false);
     const [currentPage, setCurrentPage] = useState<SettingsPage>('timer');
 
-    // Charger les paramètres depuis le service au démarrage
+    // Load settings from service on startup
     useEffect(() => {
         const timerState = timerService.getState();
         setSettings(timerState.settings);
@@ -49,9 +49,9 @@ export const Settings: FC = () => {
     const handleSettingChange = (key: keyof PomodoroSettings, value: number | boolean) => {
         setSettings(prev => {
             const newSettings = { ...prev, [key]: value };
-            // Sauvegarder immédiatement les changements
+            // Save changes immediately
             Cookies.set("pomodoroSettings", JSON.stringify(newSettings), { expires: 365 });
-            // Mettre à jour le service avec les nouveaux paramètres
+            // Update service with new settings
             timerService.updateSettings(newSettings);
             return newSettings;
         });

--- a/src/Views/Components/Settings/Settings.tsx
+++ b/src/Views/Components/Settings/Settings.tsx
@@ -126,7 +126,7 @@ export const Settings: FC = () => {
                 </div>
 
                 {/* Content */}
-                <div className="flex-1 flex flex-col justify-between p-6 w-sm sm:w-lg">
+                <div className="flex-1 flex flex-col justify-between p-6 pb-0 w-sm sm:w-lg">
                     <div className="flex-1">
                         <div className="container mx-auto px-4 sm:px-6">
                             <div className="max-w-screen-sm mx-auto">

--- a/src/Views/Components/Timer/Timer.tsx
+++ b/src/Views/Components/Timer/Timer.tsx
@@ -13,6 +13,7 @@ interface PomodoroSettings {
     shortBreakDuration: number;
     longBreakDuration: number;
     cyclesBeforeLongBreak: number;
+    manualMode: boolean;
 }
 
 export const Timer: FC = () => {
@@ -29,6 +30,7 @@ export const Timer: FC = () => {
         shortBreakDuration: 5,
         longBreakDuration: 15,
         cyclesBeforeLongBreak: 4,
+        manualMode: false,
     });
     const [soundEnabled, setSoundEnabled] = useState<boolean>(true);
 

--- a/src/Views/Components/Timer/Timer.tsx
+++ b/src/Views/Components/Timer/Timer.tsx
@@ -19,7 +19,7 @@ interface PomodoroSettings {
 export const Timer: FC = () => {
     const { t } = useTranslation();
     
-    // États locaux pour le rendu
+    // Local states for rendering
     const [timeLeft, setTimeLeft] = useState<number>(0);
     const [isRunning, setIsRunning] = useState<boolean>(false);
     const [isWorkCycle, setIsWorkCycle] = useState<boolean>(true);
@@ -39,12 +39,12 @@ export const Timer: FC = () => {
     const breakSoundRef = useRef<HTMLAudioElement | null>(null);
     const completeSoundRef = useRef<HTMLAudioElement | null>(null);
     
-    // Pour suivre le changement d'état précédent
+    // To track previous state
     const prevRunningRef = useRef(false);
     const prevWorkCycleRef = useRef(true);
     const prevNeedsLongBreakRef = useRef(false);
 
-    // Synchroniser l'état local avec le service
+    // Synchronize local state with service
     useEffect(() => {
         const syncWithService = () => {
             const state = timerService.getState();
@@ -56,13 +56,13 @@ export const Timer: FC = () => {
             setSettings(state.settings);
         };
         
-        // Synchronisation initiale
+        // Initial synchronization
         syncWithService();
         
-        // S'abonner aux mises à jour
+        // Subscribe to updates
         const unsubscribe = timerService.subscribe(syncWithService);
         
-        // Se désabonner lors du nettoyage
+        // Unsubscribe on cleanup
         return unsubscribe;
     }, []);
 
@@ -114,21 +114,21 @@ export const Timer: FC = () => {
         }
     };
 
-    // Jouer les sons au changement d'état du timer
+    // Play sounds on timer state change
     useEffect(() => {
-        // Ne pas jouer de son lors du premier rendu
+        // Don't play sound on first render
         if (prevRunningRef.current === isRunning && 
             prevWorkCycleRef.current === isWorkCycle && 
             prevNeedsLongBreakRef.current === needsLongBreak) {
             return;
         }
         
-        // Mettre à jour les références
+        // Update references
         prevRunningRef.current = isRunning;
         prevWorkCycleRef.current = isWorkCycle;
         prevNeedsLongBreakRef.current = needsLongBreak;
         
-        // Jouer le son en fonction de l'état actuel
+        // Play sound based on current state
         if (isRunning) {
             if (isWorkCycle) {
                 playSound('start');

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -30,6 +30,12 @@
             "enabled": "Notifications enabled",
             "disabled": "Notifications disabled",
             "permission": "Allow notifications to get alerts when cycles end"
+        },
+        "mode": {
+            "manualMode": "Manual Mode",
+            "autoMode": "Auto Mode",
+            "manualModeDescription": "Press play to continue",
+            "autoModeDescription": "Automatic transition"
         }
     },
     "timer": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -30,6 +30,11 @@
             "enabled": "Notifications activées",
             "disabled": "Notifications désactivées",
             "permission": "Autorisez les notifications pour être alerté à la fin des cycles"
+        },
+        "mode": {
+            "manualMode": "Mode Manuel",
+            "manualModeDescription": "appuyer sur le bouton pour continuer",
+            "autoModeDescription": "enchaînement automatique sans intervention"
         }
     },
     "timer": {

--- a/src/services/TimerService.ts
+++ b/src/services/TimerService.ts
@@ -35,7 +35,7 @@ class TimerService {
     private intervalId: number | null = null;
 
     private constructor() {
-        // Initialiser l'état avec des valeurs par défaut
+        // Initialize state with default values
         this.state = {
             timeLeft: defaultSettings.workDuration * 60,
             isRunning: false,
@@ -47,7 +47,7 @@ class TimerService {
             lastUpdatedAt: Date.now()
         };
 
-        // Charger les paramètres sauvegardés
+        // Load saved settings
         this.loadSettings();
     }
 
@@ -64,7 +64,7 @@ class TimerService {
             try {
                 const parsedSettings = JSON.parse(savedSettings);
                 this.state.settings = parsedSettings;
-                // Ne réinitialise pas les indicateurs si on est en cours de session
+                // Don't reset indicators if we're in the middle of a session
                 if (this.state.indicators.every(state => state === IndicatorState.NotStarted)) {
                     this.state.indicators = Array(parsedSettings.cyclesBeforeLongBreak).fill(IndicatorState.NotStarted) as IndicatorState[];
                 }
@@ -73,31 +73,31 @@ class TimerService {
             }
         }
 
-        // Charger l'état du timer si disponible
+        // Load timer state if available
         const savedTimerState = Cookies.get("timerState");
         if (savedTimerState) {
             try {
                 const parsedState = JSON.parse(savedTimerState) as Partial<TimerState>;
                 const lastUpdatedAt = parsedState.lastUpdatedAt || Date.now();
                 
-                // Si le timer était en cours, calculer le temps écoulé depuis
+                // If timer was running, calculate elapsed time
                 if (parsedState.isRunning && parsedState.timeLeft) {
                     const elapsedSeconds = Math.floor((Date.now() - lastUpdatedAt) / 1000);
                     const newTimeLeft = Math.max(0, parsedState.timeLeft - elapsedSeconds);
                     
-                    // Si le temps est écoulé, on gère le cycle suivant au prochain démarrage
+                    // If time is up, handle next cycle on next start
                     if (newTimeLeft <= 0) {
                         parsedState.isRunning = false;
-                        parsedState.timeLeft = 1; // On laisse 1 seconde pour que handleCycleEnd soit déclenché
+                        parsedState.timeLeft = 1; // Leave 1 second for handleCycleEnd to be triggered
                     } else {
                         parsedState.timeLeft = newTimeLeft;
                     }
                 }
                 
-                // Mettre à jour l'état avec les valeurs sauvegardées
+                // Update state with saved values
                 Object.assign(this.state, parsedState, { lastUpdatedAt: Date.now() });
                 
-                // Redémarrer l'interval si le timer est en cours
+                // Restart interval if timer is running
                 if (this.state.isRunning) {
                     this.startInterval();
                 }
@@ -113,13 +113,13 @@ class TimerService {
                 ...this.state,
                 lastUpdatedAt: Date.now()
             };
-            Cookies.set("timerState", JSON.stringify(stateToSave), { expires: 1 }); // Expire en 1 jour
+            Cookies.set("timerState", JSON.stringify(stateToSave), { expires: 1 }); // Expires in 1 day
         } catch (error) {
             console.error("Error saving timer state:", error);
         }
     }
 
-    // Démarrer l'intervalle pour décompter le temps
+    // Start interval to count down time
     private startInterval() {
         if (this.intervalId) {
             clearInterval(this.intervalId);
@@ -130,7 +130,7 @@ class TimerService {
         }, 1000);
     }
 
-    // Arrêter l'intervalle
+    // Stop interval
     private stopInterval() {
         if (this.intervalId) {
             clearInterval(this.intervalId);
@@ -138,7 +138,7 @@ class TimerService {
         }
     }
 
-    // Mettre à jour le temps restant
+    // Update remaining time
     private updateTimeLeft() {
         if (this.state.timeLeft <= 1) {
             this.stopInterval();
@@ -153,40 +153,40 @@ class TimerService {
         this.notifyListeners();
     }
 
-    // Gérer la fin d'un cycle
+    // Handle cycle end
     private handleCycleEnd() {
         if (this.state.isWorkCycle) {
-            // Fin d'un cycle de travail
+            // End of work cycle
             const updatedIndicators: IndicatorState[] = [...this.state.indicators];
             updatedIndicators[this.state.currentCycle] = IndicatorState.Completed;
             this.state.indicators = updatedIndicators;
 
-            // Vérifier si tous les cycles sont terminés
+            // Check if all cycles are completed
             if (this.state.currentCycle >= this.state.settings.cyclesBeforeLongBreak - 1) {
-                // Tous les cycles sont terminés, commencer la pause longue
+                // All cycles completed, start long break
                 this.state.needsLongBreak = true;
                 this.state.timeLeft = this.state.settings.longBreakDuration * 60;
             } else {
-                // Commencer une pause standard
+                // Start standard break
                 this.state.timeLeft = this.state.settings.shortBreakDuration * 60;
             }
 
             this.state.isWorkCycle = false;
             
-            // Redémarrer automatiquement seulement si on n'est pas en mode manuel
+            // Auto-restart only if not in manual mode
             if (!this.state.settings.manualMode) {
                 this.toggleTimer();
             } else {
-                // Jouer un son de notification en mode manuel
+                // Play notification sound in manual mode
                 this.playNotificationSound();
             }
         } else {
-            // Fin d'un cycle de pause
+            // End of break cycle
             if (this.state.needsLongBreak) {
-                // Fin de pause longue, tout réinitialiser
+                // End of long break, reset everything
                 this.resetAll();
                 
-                // Redémarrer automatiquement un nouveau cycle complet seulement si on n'est pas en mode manuel
+                // Auto-restart new complete cycle only if not in manual mode
                 if (!this.state.settings.manualMode) {
                     const updatedIndicators: IndicatorState[] = [...this.state.indicators];
                     updatedIndicators[0] = IndicatorState.InProgress;
@@ -194,15 +194,15 @@ class TimerService {
                     this.state.timeLeft = this.state.settings.workDuration * 60;
                     this.toggleTimer();
                 } else {
-                    // Jouer un son de notification en mode manuel
+                    // Play notification sound in manual mode
                     this.playNotificationSound();
                 }
             } else {
-                // Passer au cycle de travail suivant
+                // Move to next work cycle
                 const nextCycle = this.state.currentCycle + 1;
                 this.state.currentCycle = nextCycle;
 
-                // Marquer le cycle suivant comme en cours
+                // Mark next cycle as in progress
                 const updatedIndicators: IndicatorState[] = [...this.state.indicators];
                 if (nextCycle < this.state.settings.cyclesBeforeLongBreak) {
                     updatedIndicators[nextCycle] = IndicatorState.InProgress;
@@ -212,11 +212,11 @@ class TimerService {
                 this.state.timeLeft = this.state.settings.workDuration * 60;
                 this.state.isWorkCycle = true;
 
-                // Redémarrer automatiquement seulement si on n'est pas en mode manuel
+                // Auto-restart only if not in manual mode
                 if (!this.state.settings.manualMode) {
                     this.toggleTimer();
                 } else {
-                    // Jouer un son de notification en mode manuel
+                    // Play notification sound in manual mode
                     this.playNotificationSound();
                 }
             }
@@ -226,7 +226,7 @@ class TimerService {
         this.notifyListeners();
     }
 
-    // Jouer un son de notification
+    // Play notification sound
     private playNotificationSound() {
         try {
             const audio = new Audio("/sounds/complete.mp3");
@@ -236,16 +236,16 @@ class TimerService {
         }
     }
 
-    // API publique
+    // Public API
     public getState(): TimerState {
         return { ...this.state };
     }
 
     public toggleTimer() {
         if (!this.state.isRunning) {
-            // Démarrer le timer
+            // Start timer
             if (this.state.indicators.every(state => state === IndicatorState.NotStarted)) {
-                // Premier démarrage
+                // First start
                 const updatedIndicators: IndicatorState[] = [...this.state.indicators];
                 updatedIndicators[0] = IndicatorState.InProgress;
                 this.state.indicators = updatedIndicators;
@@ -256,7 +256,7 @@ class TimerService {
             this.state.isRunning = true;
             this.startInterval();
         } else {
-            // Arrêter le timer
+            // Stop timer
             this.state.isRunning = false;
             this.stopInterval();
         }
@@ -266,10 +266,10 @@ class TimerService {
     }
 
     public resetAll() {
-        // Arrêter le timer
+        // Stop timer
         this.stopInterval();
         
-        // Réinitialiser tous les états
+        // Reset all states
         this.state.isRunning = false;
         this.state.timeLeft = this.state.settings.workDuration * 60;
         this.state.isWorkCycle = true;
@@ -284,7 +284,7 @@ class TimerService {
     public updateSettings(settings: PomodoroSettings) {
         this.state.settings = { ...settings };
         
-        // Mettre à jour le temps restant en fonction du type de cycle actuel
+        // Update remaining time based on current cycle type
         if (this.state.isWorkCycle) {
             this.state.timeLeft = settings.workDuration * 60;
         } else if (this.state.needsLongBreak) {
@@ -293,12 +293,12 @@ class TimerService {
             this.state.timeLeft = settings.shortBreakDuration * 60;
         }
         
-        // Mettre à jour les indicateurs si nécessaire
+        // Update indicators if necessary
         if (settings.cyclesBeforeLongBreak !== this.state.indicators.length) {
-            // Préserver les états existants lors du redimensionnement
+            // Preserve existing states during resize
             const newIndicators: IndicatorState[] = Array(settings.cyclesBeforeLongBreak).fill(IndicatorState.NotStarted) as IndicatorState[];
             
-            // Copier les états existants
+            // Copy existing states
             for (let i = 0; i < Math.min(this.state.indicators.length, newIndicators.length); i++) {
                 newIndicators[i] = this.state.indicators[i];
             }
@@ -310,7 +310,7 @@ class TimerService {
         this.notifyListeners();
     }
 
-    // Système d'abonnement pour les composants
+    // Subscription system for components
     public subscribe(listener: () => void): () => void {
         this.listeners.push(listener);
         return () => {


### PR DESCRIPTION
Close #8 
This pull request introduces a new "Manual Mode" feature to the Pomodoro Timer application, allowing users to manually transition between cycles instead of automatic transitions. It includes updates to the settings interface, timer logic, and localization files to support this feature. Additionally, there is a minor update to the `.auto-changelog` configuration.

### New "Manual Mode" Feature:

#### Timer Logic Updates:
* Added a `manualMode` property to the `PomodoroSettings` interface and updated the default settings to include `manualMode: false`. (`src/services/TimerService.ts`, `src/Views/Components/Timer/Timer.tsx`, `src/Views/Components/Settings/Settings.tsx`) [[1]](diffhunk://#diff-aeb96db673ac1273957a845878ff868a6c7e2b2cc2885401b277545f7a33daa1R9-R17) [[2]](diffhunk://#diff-56bd0b66a8186143194dbd417ba542c946ee59d2b575bb4ea119249db8e30cdfR16) [[3]](diffhunk://#diff-8c66f459e9a8bbe7165ea7191760f1a661d24ea42696178108fac83c9f86f83aR17-R25)
* Modified the `TimerService` class to check the `manualMode` setting before automatically restarting cycles. In manual mode, a notification sound is played instead of automatically transitioning. (`src/services/TimerService.ts`) [[1]](diffhunk://#diff-aeb96db673ac1273957a845878ff868a6c7e2b2cc2885401b277545f7a33daa1L174-R199) [[2]](diffhunk://#diff-aeb96db673ac1273957a845878ff868a6c7e2b2cc2885401b277545f7a33daa1L203-R238)

#### UI and Settings Updates:
* Updated the `TimerSettings` component to include a toggle for "Manual Mode" with corresponding icons and descriptions. (`src/Views/Components/Settings/Sections/TimerSettings.tsx`) [[1]](diffhunk://#diff-1859004ee7421bed3333eaf422a0caa48b0e39f19393759444f1e7400fb2614fR4-R34) [[2]](diffhunk://#diff-1859004ee7421bed3333eaf422a0caa48b0e39f19393759444f1e7400fb2614fR67-R101)
* Adjusted the `Settings` component to handle changes to the `manualMode` setting. (`src/Views/Components/Settings/Settings.tsx`) [[1]](diffhunk://#diff-8c66f459e9a8bbe7165ea7191760f1a661d24ea42696178108fac83c9f86f83aL47-R49) [[2]](diffhunk://#diff-8c66f459e9a8bbe7165ea7191760f1a661d24ea42696178108fac83c9f86f83aL129-R131)

#### Localization:
* Added translations for "Manual Mode" and "Auto Mode" labels and descriptions in English and French. (`src/i18n/locales/en.json`, `src/i18n/locales/fr.json`) [[1]](diffhunk://#diff-86d6ad78f4bfa98b2f9fc37e63d2f4c94b23dc54736ab069327947546c55ccd0R33-R38) [[2]](diffhunk://#diff-3fd7d960270a3362b3854c3d58b2cb601768e05364c45997d408e45c90a55002R33-R37)

### Minor Configuration Update:
* Updated the `issueUrl` in the `.auto-changelog` configuration to point to the correct GitHub repository. (`.auto-changelog`)