### PR TITLE
add progress view on tab title

### DIFF
--- a/src/Views/Components/Timer/Timer.tsx
+++ b/src/Views/Components/Timer/Timer.tsx
@@ -229,6 +229,28 @@ export const Timer: FC = () => {
         notifyState();
     }, [isWorkCycle, needsLongBreak, isRunning]);
 
+    // Update document title with timer progress
+    useEffect(() => {
+        const totalTime = isWorkCycle
+            ? settings.workDuration * 60
+            : needsLongBreak ? settings.longBreakDuration * 60 : settings.shortBreakDuration * 60;
+        
+        const progress = Math.round((1 - timeLeft / totalTime) * 100);
+        const timeString = formatTime(timeLeft);
+        const cycleType = isWorkCycle 
+            ? t('timer.workTime')
+            : needsLongBreak 
+                ? t('timer.longBreak')
+                : t('timer.shortBreak');
+        
+        document.title = `${timeString} - ${cycleType} (${progress}%)`;
+        
+        // Reset title when timer is not running
+        if (!isRunning) {
+            document.title = 'Pomodoro Timer';
+        }
+    }, [timeLeft, isRunning, isWorkCycle, needsLongBreak, settings, t]);
+
     return (
         <div className="flex-1 flex flex-col">
             <div className="flex-1 flex flex-col justify-center">


### PR DESCRIPTION
Close #11 
This pull request introduces a feature to dynamically update the browser's document title with the timer's progress, providing users with real-time feedback on their Pomodoro session. The document title now reflects the remaining time, cycle type, and progress percentage, and resets to "Pomodoro Timer" when the timer is not running.

### Timer functionality enhancement:

* [`src/Views/Components/Timer/Timer.tsx`](diffhunk://#diff-56bd0b66a8186143194dbd417ba542c946ee59d2b575bb4ea119249db8e30cdfR232-R253): Added a `useEffect` hook to update the document title with the timer's remaining time, cycle type (work time, long break, or short break), and progress percentage. The title resets to "Pomodoro Timer" when the timer is not running.