### PR TITLE
add skip button

### DIFF
--- a/src/Views/Components/Timer/Timer.tsx
+++ b/src/Views/Components/Timer/Timer.tsx
@@ -310,6 +310,13 @@ export const Timer: FC = () => {
                             className="text-5xl! sm:text-7xl!"
                         />
                     </div>
+                    <div className="hover:cursor-pointer flex flex-col justify-center" onClick={() => timerService.skipStep()}>
+                        <Icon
+                            code="skip_next"
+                            fill={false}
+                            className="text-3xl! sm:text-4xl!"
+                        />
+                    </div>
                     <div className="hover:cursor-pointer flex flex-col justify-center" onClick={toggleSound}>
                         <Icon
                             code={soundEnabled ? "volume_up" : "volume_off"}

--- a/src/services/TimerService.ts
+++ b/src/services/TimerService.ts
@@ -281,6 +281,18 @@ class TimerService {
         this.notifyListeners();
     }
 
+    public skipStep() {
+        // Stop current timer
+        this.stopInterval();
+        this.state.isRunning = false;
+        
+        // Handle the current cycle end
+        this.handleCycleEnd();
+        
+        this.saveState();
+        this.notifyListeners();
+    }
+
     public updateSettings(settings: PomodoroSettings) {
         this.state.settings = { ...settings };
         


### PR DESCRIPTION
Close #10 
This pull request introduces a new "Skip Step" feature to the Timer component, allowing users to manually advance to the next step in the Pomodoro cycle. The changes include updates to both the UI and the underlying service logic to support this functionality.

### UI Enhancements:

* [`src/Views/Components/Timer/Timer.tsx`](diffhunk://#diff-56bd0b66a8186143194dbd417ba542c946ee59d2b575bb4ea119249db8e30cdfR313-R319): Added a new clickable icon (`skip_next`) to the Timer component that triggers the `skipStep` method in the `TimerService`. This icon is styled for responsiveness and includes hover effects for better user experience.

### Service Logic Updates:

* [`src/services/TimerService.ts`](diffhunk://#diff-aeb96db673ac1273957a845878ff868a6c7e2b2cc2885401b277545f7a33daa1R284-R295): Introduced a new `skipStep` method in the `TimerService` class. This method stops the current timer, handles the end of the current cycle, updates the state, and notifies listeners to reflect the changes.